### PR TITLE
69 implement connection recovery for pika based rabbitmq connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,10 @@ Changed:
 - Made `manager`, `managed_application`, and `logger_application` YAML fields optional (64-make-logger_application-field-optional-in-execution-section-of-pydantic-class)
 - Updated defaults values for `pika.connection.ConnectionParameters` and `pika.spec.BasicProperties` to mirror those of Pika if not set in YAML file (66-update-ssltls-configuration)
 - Updated SSL configuration to use `ssl.create_default_context()` (66-update-ssltls-configuration)
+
+## 2.0.2
+Added:
+- Added optional `reconnect_delay` YAML field in the `servers`.`rabbitmq` section, with default value of 10 seconds.
+
+Changed:
+- Updated `on_close_callback` of `pika.SelectConnection` to react to connection failure events. The callback attempts to recover the connection.

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -244,6 +244,7 @@ class RabbitMQConfig(BaseModel):
     blocked_connection_timeout: int = Field(
         None, description="Timeout for blocked connections."
     )
+    reconnect_delay: int = Field(10, description="Reconnect delay, in seconds.")
 
 
 class KeycloakConfig(BaseModel):


### PR DESCRIPTION
- Adds connection recovery for Pika-based RabbitMQ connections using `on_close_callback`
- Adds optional `servers.rabbitmq.reconnect_delay` YAML field for connection recovery reconnection delay, with default value of 10 seconds. 