### PR TITLE
71 make keycloak field optional in servers section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Changed:
 ## 2.0.2
 Added:
 - Added optional `reconnect_delay` YAML field in the `servers`.`rabbitmq` section, with default value of 10 seconds.
+- Used `model_validator` to check `servers.rabbitmq.keycloak_authentication`. If `servers.rabbitmq.keycloak_authentication` is `True` and `servers.keycloak` is `None`, raise a `ValueError`.
 
 Changed:
 - Updated `on_close_callback` of `pika.SelectConnection` to react to connection failure events. The callback attempts to recover the connection.
+- Made `servers.keycloak` YAML field optional. When running NOS-T Tools on localhost, `servers.keycloak` is not necessary, so it is now optional.

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -259,7 +259,25 @@ class KeycloakConfig(BaseModel):
 
 class ServersConfig(BaseModel):
     rabbitmq: RabbitMQConfig = Field(..., description="RabbitMQ configuration.")
-    keycloak: KeycloakConfig = Field(..., description="Keycloak configuration.")
+    keycloak: Optional[KeycloakConfig] = Field(
+        None, description="Keycloak configuration."
+    )
+
+    @model_validator(mode="before")
+    def validate_keycloak_authentication(cls, values):
+        rabbitmq_config = values.get("rabbitmq")
+        keycloak_config = values.get("keycloak")
+    
+        # Check if rabbitmq_config is a dictionary and validate the keycloak_authentication key
+        if (
+            isinstance(rabbitmq_config, dict)
+            and rabbitmq_config.get("keycloak_authentication", False)
+            and not keycloak_config
+        ):
+            raise ValueError(
+                "Keycloak authentication is enabled, but the Keycloak configuration is missing."
+            )
+        return values
 
 
 class GeneralConfig(BaseModel):
@@ -375,9 +393,13 @@ class LoggerApplicationConfig(BaseModel):
 
 class ExecConfig(BaseModel):
     general: GeneralConfig
-    manager: Optional[ManagerConfig] = None
-    managed_application: Optional[ManagedApplicationConfig] = None
-    logger_application: Optional[LoggerApplicationConfig] = None
+    manager: Optional[ManagerConfig] = Field(None, description="Manager configuration.")
+    managed_application: Optional[ManagedApplicationConfig] = Field(
+        None, description="Managed application configuration."
+    )
+    logger_application: Optional[LoggerApplicationConfig] = Field(
+        None, description="Logger application configuration."
+    )
 
 
 class Config(BaseModel):


### PR DESCRIPTION
- Made `servers.keycloak` YAML field optional. When running NOS-T Tools on localhost, `servers.keycloak` is not necessary, so it is now optional.
- Used `model_validator` to check `servers.rabbitmq.keycloak_authentication`. If `servers.rabbitmq.keycloak_authentication` is `True` and `servers.keycloak` is `None`, raise a `ValueError`.
