### PR TITLE
76 allow separate execution parameters for each managed application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,10 @@ Changed:
 - Updated `on_close_callback` of `pika.SelectConnection` to react to connection failure events. The callback attempts to recover the connection.
 - Made `servers.keycloak` YAML field optional. When running NOS-T Tools on localhost, `servers.keycloak` is not necessary, so it is now optional.
 - Fixed scaling of `time_status_step` in `ManagerConfig`, and `time_step` and `time_status_step` in `ManagedApplicationConfig`. The code now correctly parses hours, minutes, and seconds from the string format "HH:MM:SS" and calculates the total seconds accordingly. Total seconds are then correctly scaled by the `time_scale_factor`.
+
+## 2.0.3
+Addded: 
+
+Changed:
+- Updated PyDantic model to allow for multiple managed applications to be configured using a dictionary for `execution.managed_applications.<app name>`. If a field is not provided, default values specified in `ManagedApplicationConfig` are used for all applications.
+- Updated the `start_up()` method to filter the necessary fields within the dictionary. Ensure that only the execution parameters for the specific application (e.g., "planner") are pulled and applied for each application separately.

--- a/nost_tools/application.py
+++ b/nost_tools/application.py
@@ -221,11 +221,15 @@ class Application:
             self.shut_down_when_terminated = shut_down_when_terminated
         else:
             self.config = config
-            parameters = getattr(
-                self.config.rc.simulation_configuration.execution_parameters,
-                self.app_name,
-                None,
+            parameters = (
+                self.config.rc.simulation_configuration.execution_parameters.managed_applications
             )
+
+            try:
+                parameters = parameters[self.app_name]
+            except KeyError:
+                parameters = parameters["default"]
+
             self.set_offset = parameters.set_offset
             self.time_status_step = parameters.time_status_step
             self.time_status_init = parameters.time_status_init

--- a/nost_tools/managed_application.py
+++ b/nost_tools/managed_application.py
@@ -86,11 +86,15 @@ class ManagedApplication(Application):
             self.manager_app_name = manager_app_name
         else:
             self.config = config
-            parameters = getattr(
-                self.config.rc.simulation_configuration.execution_parameters,
-                "managed_application",
-                None,
+            parameters = (
+                self.config.rc.simulation_configuration.execution_parameters.managed_applications
             )
+
+            try:
+                parameters = parameters[self.app_name]
+            except KeyError:
+                parameters = parameters["default"]
+
             self.set_offset = parameters.set_offset
             self.time_status_step = parameters.time_status_step
             self.time_status_init = parameters.time_status_init

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -397,8 +397,9 @@ class LoggerApplicationConfig(BaseModel):
 class ExecConfig(BaseModel):
     general: GeneralConfig
     manager: Optional[ManagerConfig] = Field(None, description="Manager configuration.")
-    managed_application: Optional[ManagedApplicationConfig] = Field(
-        None, description="Managed application configuration."
+    managed_applications: Optional[Dict[str, ManagedApplicationConfig]] = Field(
+        default_factory=lambda: {"default": ManagedApplicationConfig()},
+        description="Dictionary of managed application configurations, keyed by application name.",
     )
     logger_application: Optional[LoggerApplicationConfig] = Field(
         None, description="Logger application configuration."


### PR DESCRIPTION
- Updated PyDantic model to allow for multiple managed applications to be configured using a dictionary for `execution.managed_applications.<app name>`. If a field is not provided, default values specified in `ManagedApplicationConfig` are used for all applications.
- Updated the `start_up()` method to filter the necessary fields within the dictionary. Ensure that only the execution parameters for the specific application (e.g., "planner") are pulled and applied for each application separately.