### PR TITLE
85 run execute test plan in a background thread to prevent connection drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,9 @@ Addded:
 Changed:
 - Updated PyDantic model to allow for multiple managed applications to be configured using a dictionary for `execution.managed_applications.<app name>`. If a field is not provided, default values specified in `ManagedApplicationConfig` are used for all applications.
 - Updated the `start_up()` method to filter the necessary fields within the dictionary. Ensure that only the execution parameters for the specific application (e.g., "planner") are pulled and applied for each application separately.
+
+## 2.0.4
+Added:
+
+Changed:
+- Refactored `manager.py` so that `execute_test_plan` always runs in a background thread.

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -98,7 +98,21 @@ class Manager(Application):
             auto_delete=True,
         )
 
-    def execute_test_plan(
+    def execute_test_plan(self, *args, **kwargs) -> None:
+        """
+        Starts the test plan execution in a background thread.
+
+        Args:
+            *args: Positional arguments to be passed to the test plan execution.
+            **kwargs: Keyword arguments to be passed to the test plan execution.
+        """
+        thread = threading.Thread(
+            target=self._execute_test_plan_impl, args=args, kwargs=kwargs, daemon=True
+        )
+        logger.debug("Running test plan in background thread.")
+        thread.start()
+
+    def _execute_test_plan_impl(
         self,
         sim_start_time: datetime = None,
         sim_stop_time: datetime = None,
@@ -163,9 +177,6 @@ class Manager(Application):
                 self.time_status_step = parameters.time_status_step
                 self.time_status_init = parameters.time_status_init
                 self.command_lead = parameters.command_lead
-                # self.required_apps = (
-                #     self.config.rc.simulation_configuration.execution_parameters.required_apps
-                # )
                 self.required_apps = [
                     app for app in parameters.required_apps if app != self.app_name
                 ]


### PR DESCRIPTION
- Refactored `manager.py` so that `execute_test_plan` always runs in a background thread.