### PR TITLE
91 ambiguity in time step and time status step configuration parameters

### DIFF
--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -379,7 +379,7 @@ class ManagedApplicationConfig(BaseModel):
     manager_app_name: str = Field("manager", description="Manager application name.")
     is_scenario_time_step: bool = Field(
         True,
-        description="If True, time_step is in scenario time and won't be scaled. If False, time_step is in wallclock time and will be scaled.",
+        description="If True, time_step is in scenario time and won't be scaled. If False, time_step is in wallclock time and will be scaled by the time scale factor.",
     )
     is_scenario_time_status_step: bool = Field(
         True,

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -339,12 +339,18 @@ class ManagerConfig(BaseModel):
     shut_down_when_terminated: bool = Field(
         False, description="Shut down when terminated."
     )
+    is_scenario_time_status_step: bool = Field(
+        True,
+        description="If True, time_status_step is in scenario time and won't be scaled. If False, time_status_step is in wallclock time and will be scaled by the time scale factor.",
+    )
 
     @model_validator(mode="before")
     def scale_time(cls, values):
         time_scale_factor = values.get("time_scale_factor", 1.0)
 
-        if "time_status_step" in values:
+        if "time_status_step" in values and not values.get(
+            "is_scenario_time_status_step", True
+        ):
             time_status_step = values["time_status_step"]
             if isinstance(time_status_step, str):
                 hours, minutes, seconds = map(int, time_status_step.split(":"))
@@ -371,12 +377,20 @@ class ManagedApplicationConfig(BaseModel):
         False, description="Shut down when terminated."
     )
     manager_app_name: str = Field("manager", description="Manager application name.")
+    is_scenario_time_step: bool = Field(
+        True,
+        description="If True, time_step is in scenario time and won't be scaled. If False, time_step is in wallclock time and will be scaled.",
+    )
+    is_scenario_time_status_step: bool = Field(
+        True,
+        description="If True, time_status_step is in scenario time and won't be scaled. If False, time_status_step is in wallclock time and will be scaled by the time scale factor.",
+    )
 
     @model_validator(mode="before")
     def scale_time(cls, values):
         time_scale_factor = values.get("time_scale_factor", 1.0)
 
-        if "time_step" in values:
+        if "time_step" in values and not values.get("is_scenario_time_step", True):
             time_step = values["time_step"]
             if isinstance(time_step, str):
                 hours, minutes, seconds = map(int, time_step.split(":"))
@@ -386,7 +400,9 @@ class ManagedApplicationConfig(BaseModel):
                     seconds=time_step.total_seconds() * time_scale_factor
                 )
 
-        if "time_status_step" in values:
+        if "time_status_step" in values and not values.get(
+            "is_scenario_time_status_step", True
+        ):
             time_status_step = values["time_status_step"]
             if isinstance(time_status_step, str):
                 hours, minutes, seconds = map(int, time_status_step.split(":"))


### PR DESCRIPTION
Introduces a new boolean flags to explicitly define the time domain for time_step and time_status_step. These flags will determine whether the associated values are interpreted in ST (unscaled) or WCT (scaled by the time scale factor).