### PR TITLE
2.3.0 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,6 @@ Added:
 - Introduced a boolean `setup_signal_handlers` (default=True) parameter for Application() class, which makes `self._setup_signal_handlers()` conditional. This prevents errors in nost-manager-backend. 
   - Added `setup_signal_handlers` argument (default=True) to `__init__` of `Manager` and `ManagedApplication` classes.
 - Added `yaml_file` section to `RuntimeConfig` in both `schemas.py` and `configuration.py`. This attribute holds the path to YAML configuration file if provided; otherwise, it defaults to `None`.
-- Removed `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py`
 - Introduced `_get_parameters_from_config()` in `Application`, `Manager`, and `ManagedApplication` to facilitate getting the application parameters from the YAML configuration or user-provided arguments based on `self.config.rc.yaml_file` being None or not. 
 
 Updated:
@@ -121,3 +120,4 @@ Updated:
   - `Application` class of `application.py`
   - `Manager` class of `manager.py`
   - `ManagedApplication` class of `managed_application.py` 
+- Updated `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py` to run only if `self.simulator.get_mode() == Mode.EXECUTING`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,9 @@ Added:
 - Added `yaml_file` section to `RuntimeConfig` in both `schemas.py` and `configuration.py`. This attribute holds the path to YAML configuration file if provided; otherwise, it defaults to `None`.
 - Introduced `_get_parameters_from_config()` in `Application`, `Manager`, and `ManagedApplication` to facilitate getting the application parameters from the YAML configuration or user-provided arguments based on `self.config.rc.yaml_file` being None or not. 
 - Added `keycloak_authentication` argument to `__init__()` of `ConnectionConfig` class (default=False).
- 
+- Implemented `start_wallclock_refresh_thread()` which periodically updates the wallclock offset. 
+- Added `WallclockOffsetProperties` to `schemas.py` that contains `wallclock_offset_refresh_interval` and `ntp_host` fields used in `start_wallclock_refresh_thread()`
+
 Updated:
 - Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.
 - Made `client_id` and `client_secret_key` in `Credentials` default to None.
@@ -123,3 +125,4 @@ Updated:
   - `ManagedApplication` class of `managed_application.py` 
 - Updated `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py` to run only if `self.simulator.get_mode() == Mode.EXECUTING`
 - Removed `time_step` and `manager_app_name` arguments from `start_up()` in `Manager` class
+- Modified `set_wallclock_offset()` in `simulator.py` to allow setting wallclock offset when in `Mode.EXECUTING`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,8 @@ Added:
   - Added `setup_signal_handlers` argument (default=True) to `__init__` of `Manager` and `ManagedApplication` classes.
 - Added `yaml_file` section to `RuntimeConfig` in both `schemas.py` and `configuration.py`. This attribute holds the path to YAML configuration file if provided; otherwise, it defaults to `None`.
 - Introduced `_get_parameters_from_config()` in `Application`, `Manager`, and `ManagedApplication` to facilitate getting the application parameters from the YAML configuration or user-provided arguments based on `self.config.rc.yaml_file` being None or not. 
-
+- Added `keycloak_authentication` argument to `__init__()` of `ConnectionConfig` class (default=False).
+ 
 Updated:
 - Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.
 - Made `client_id` and `client_secret_key` in `Credentials` default to None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ Updated:
 - Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.
 - Made `client_id` and `client_secret_key` in `Credentials` default to None.
 - Changed `parameters.time_scale_updates` reference to `self.time_scale_updates` in `manager.py`.
-- Updated code in `start_up()` related to definition of parameters to use `_get_parameters_from_config()` subclasses to customize parameter retrieval in:
+- Updated code in `start_up()` related to the definition of parameters to use `_get_parameters_from_config()` subclasses to customize parameter retrieval in:
   - `Application` class of `application.py`
   - `Manager` class of `manager.py`
   - `ManagedApplication` class of `managed_application.py` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Changed:
   - Improve general code structure for enhanced efficiency, readability, and user experience
 - Updated documentation for the FireSat+, Downlink, Scalability, and scienceDash test suites.
 
-## 2.2.1
+## 2.3.0
 Added:
 - Introduced a boolean `setup_signal_handlers` (default=True) parameter for Application() class, which makes `self._setup_signal_handlers()` conditional. This prevents errors in nost-manager-backend. 
   - Added `setup_signal_handlers` argument (default=True) to `__init__` of `Manager` and `ManagedApplication` classes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Added:
 - Added `keycloak_authentication` argument to `__init__()` of `ConnectionConfig` class (default=False).
 - Implemented `start_wallclock_refresh_thread()` which periodically updates the wallclock offset. 
 - Added `WallclockOffsetProperties` to `schemas.py` that contains `wallclock_offset_refresh_interval` and `ntp_host` fields used in `start_wallclock_refresh_thread()`
+- Implemented `is_scenario_time_step` in `ManagerConfig` class, similar to that of `ManagedApplicationConfig`
 
 Updated:
 - Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,20 @@ Changed:
   - Define application-specific settings under the `execution.managed_applications.<application name>.configuration_parameters` field instead of the previous `config.py`
   - Improve general code structure for enhanced efficiency, readability, and user experience
 - Updated documentation for the FireSat+, Downlink, Scalability, and scienceDash test suites.
+
+## 2.2.1
+Added:
+- Introduced a boolean `setup_signal_handlers` (default=True) parameter for Application() class, which makes `self._setup_signal_handlers()` conditional. This prevents errors in nost-manager-backend. 
+  - Added `setup_signal_handlers` argument (default=True) to `__init__` of `Manager` and `ManagedApplication` classes.
+- Added `yaml_file` section to `RuntimeConfig` in both `schemas.py` and `configuration.py`. This attribute holds the path to YAML configuration file if provided; otherwise, it defaults to `None`.
+- Removed `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py`
+- Introduced `_get_parameters_from_config()` in `Application`, `Manager`, and `ManagedApplication` to facilitate getting the application parameters from the YAML configuration or user-provided arguments based on `self.config.rc.yaml_file` being None or not. 
+
+Updated:
+- Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.
+- Made `client_id` and `client_secret_key` in `Credentials` default to None.
+- Changed `parameters.time_scale_updates` reference to `self.time_scale_updates` in `manager.py`.
+- Updated code in `start_up()` related to definition of parameters to use `_get_parameters_from_config()` in: 
+  - `Application` class of `application.py`
+  - `Manager` class of `manager.py`
+  - `ManagedApplication` class of `managed_application.py` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ Updated:
 - Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.
 - Made `client_id` and `client_secret_key` in `Credentials` default to None.
 - Changed `parameters.time_scale_updates` reference to `self.time_scale_updates` in `manager.py`.
-- Updated code in `start_up()` related to definition of parameters to use `_get_parameters_from_config()` in: 
+- Updated code in `start_up()` related to definition of parameters to use `_get_parameters_from_config()` subclasses to customize parameter retrieval in:
   - `Application` class of `application.py`
   - `Manager` class of `manager.py`
   - `ManagedApplication` class of `managed_application.py` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,4 @@ Updated:
   - `Manager` class of `manager.py`
   - `ManagedApplication` class of `managed_application.py` 
 - Updated `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py` to run only if `self.simulator.get_mode() == Mode.EXECUTING`
+- Removed `time_step` and `manager_app_name` arguments from `start_up()` in `Manager` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,3 +126,4 @@ Updated:
 - Updated `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py` to run only if `self.simulator.get_mode() == Mode.EXECUTING`
 - Removed `time_step` and `manager_app_name` arguments from `start_up()` in `Manager` class
 - Modified `set_wallclock_offset()` in `simulator.py` to allow setting wallclock offset when in `Mode.EXECUTING`
+- Update default value of `time_status_init` to `datetime.now()` in `ApplicationConfig` class

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 2.2.0
+version: 2.3.0
 doi:
 date-released: 2025-06-04
 url: "https://github.com/code-lab-org/nost-tools"

--- a/examples/scalability/delay/main_delay.py
+++ b/examples/scalability/delay/main_delay.py
@@ -180,10 +180,7 @@ class HeartbeatDelayRecorder:
             print("Manager initiated simulation")
         elif topic == f"{PREFIX}.manager.stop":
             print("Manager published stop message")
-            print(self._wallclock_offset)
-            self.sim_end_time = pd.to_datetime(
-                data["taskingParameters"]["simStopTime"]
-            )
+            self.sim_end_time = pd.to_datetime(data["taskingParameters"]["simStopTime"])
         elif topic == f"{PREFIX}.heartbeat.settings":
             print("Heartbeat application settings detected")
             self.msg_periodicity = float(data["periodicity"])
@@ -191,11 +188,9 @@ class HeartbeatDelayRecorder:
 
         for i, application in enumerate(self.names):
             if topic == f"{PREFIX}.status.{application}.time":
-                print("Heartbeat application time status message received")
                 msgId = len(self.msg_dictionaries[application])
                 timeStamp = pd.to_datetime(data["properties"]["time"])
                 if self.sim_end_time != None:
-                    print("Checking if simulation end time has been reached.")
                     scenarioTime = pd.to_datetime(data["properties"]["simTime"])
                     if scenarioTime >= self.sim_end_time:
                         if self.channel:
@@ -290,7 +285,6 @@ if __name__ == "__main__":
 
     # Bind queue to all routing keys
     for routing_key in routing_keys:
-        print(routing_key)
         channel.queue_bind(
             exchange=exchange_name, queue=queue_name, routing_key=routing_key
         )

--- a/examples/scalability/delay/main_delay.py
+++ b/examples/scalability/delay/main_delay.py
@@ -183,7 +183,7 @@ class HeartbeatDelayRecorder:
             print(self._wallclock_offset)
             self.sim_end_time = pd.to_datetime(
                 data["taskingParameters"]["simStopTime"]
-            )  # - timedelta(seconds=4)
+            )
         elif topic == f"{PREFIX}.heartbeat.settings":
             print("Heartbeat application settings detected")
             self.msg_periodicity = float(data["periodicity"])
@@ -197,9 +197,6 @@ class HeartbeatDelayRecorder:
                 if self.sim_end_time != None:
                     print("Checking if simulation end time has been reached.")
                     scenarioTime = pd.to_datetime(data["properties"]["simTime"])
-                    # scenarioTime += timedelta(seconds=4)
-                    print(scenarioTime)
-                    print(self.sim_end_time)
                     if scenarioTime >= self.sim_end_time:
                         if self.channel:
                             self.channel.stop_consuming()
@@ -264,8 +261,7 @@ if __name__ == "__main__":
     parameters = pika.ConnectionParameters(
         host=HOST,
         credentials=credentials,
-        # ssl=True,  # Enable SSL
-        port=PORT,  # Default AMQPS port
+        port=PORT,
     )
 
     connection = pika.BlockingConnection(parameters)

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/application.py
+++ b/nost_tools/application.py
@@ -91,6 +91,9 @@ class Application:
         self._token_refresh_thread = None
         self.token_refresh_interval = None
         self._reconnect_delay = None
+        # Offset
+        self._wallclock_refresh_thread = None
+        self.wallclock_offset_refresh_interval = None
         # Set up signal handlers for graceful shutdown
         if setup_signal_handlers:
             self._setup_signal_handlers()
@@ -201,6 +204,42 @@ class Application:
         self._token_refresh_thread.start()
         logger.debug("Starting refresh token thread successfully completed.")
 
+    def start_wallclock_refresh_thread(self):  # , interval=30, host="pool.ntp.org"):
+        """
+        Starts a background thread to refresh the wallclock offset periodically.
+
+        Args:
+            interval (int): Seconds between wallclock offset refreshes (default: 3600 seconds/1 hour)
+            host (str): NTP host to query (default: 'pool.ntp.org')
+        """
+        logger.debug("Starting wallclock offset refresh thread.")
+
+        def refresh_wallclock_periodically():
+            while not self._should_stop.wait(
+                timeout=self.config.rc.wallclock_offset_properties.wallclock_offset_refresh_interval
+            ):
+                logger.debug("Wallclock refresh thread is running.")
+                try:
+                    logger.info(
+                        f"Contacting {self.config.rc.wallclock_offset_properties.ntp_host} to retrieve wallclock offset."
+                    )
+                    response = ntplib.NTPClient().request(
+                        self.config.rc.wallclock_offset_properties.ntp_host,
+                        version=3,
+                        timeout=2,
+                    )
+                    offset = timedelta(seconds=response.offset)
+                    self.simulator.set_wallclock_offset(offset)
+                    logger.info(f"Wallclock offset updated to {offset}.")
+                except Exception as e:
+                    logger.debug(f"Failed to refresh wallclock offset: {e}")
+
+        self._wallclock_refresh_thread = threading.Thread(
+            target=refresh_wallclock_periodically
+        )
+        self._wallclock_refresh_thread.start()
+        logger.debug("Starting wallclock offset refresh thread successfully completed.")
+
     def update_connection_credentials(self, access_token):
         """
         Updates the connection credentials with the new access token.
@@ -285,8 +324,11 @@ class Application:
             self.shut_down_when_terminated = shut_down_when_terminated
 
         if self.set_offset:
-            # Set the system clock offset
-            self.set_wallclock_offset()
+            # Start periodic wallclock offset updates instead of one-time call
+            logger.info(
+                f"Wallclock offset will be set every {self.config.rc.wallclock_offset_properties.wallclock_offset_refresh_interval} seconds using {self.config.rc.wallclock_offset_properties.ntp_host}."
+            )
+            self.start_wallclock_refresh_thread()
 
         # Set the prefix and configuration parameters
         self.prefix = prefix
@@ -1384,33 +1426,25 @@ class Application:
                     )
                 else:
                     logger.info("Closing token refresh thread completed successfully")
-
+            # Also stop wallclock refresh thread if it exists
+            if (
+                hasattr(self, "_wallclock_refresh_thread")
+                and self._wallclock_refresh_thread
+                and self._wallclock_refresh_thread.is_alive()
+            ):
+                logger.info("Closing wallclock refresh thread.")
+                # Set a timeout to avoid hanging indefinitely
+                self._wallclock_refresh_thread.join(timeout=60.0)
+                # Check if it's still alive after timeout
+                if self._wallclock_refresh_thread.is_alive():
+                    logger.warning(
+                        "Closing wallclock refresh thread timed out after 60 seconds. "
+                    )
+                else:
+                    logger.info(
+                        "Closing wallclock refresh thread completed successfully"
+                    )
             logger.debug("Stop_application completed successfully.")
-
-    def set_wallclock_offset(
-        self, host="pool.ntp.org", retry_delay_s: int = 5, max_retry: int = 5
-    ) -> None:
-        """
-        Issues a Network Time Protocol (NTP) request to determine the system clock offset.
-
-        Args:
-            host (str): NTP host (default: 'pool.ntp.org')
-            retry_delay_s (int): number of seconds to wait before retrying
-            max_retry (int): maximum number of retries allowed
-        """
-        for i in range(max_retry):
-            try:
-                logger.info(f"Contacting {host} to retrieve wallclock offset.")
-                response = ntplib.NTPClient().request(host, version=3, timeout=2)
-                offset = timedelta(seconds=response.offset)
-                self.simulator.set_wallclock_offset(offset)
-                logger.info(f"Wallclock offset updated to {offset}.")
-                return
-            except ntplib.NTPException:
-                logger.warning(
-                    f"Could not connect to {host}, attempt #{i+1}/{max_retry} in {retry_delay_s} s."
-                )
-                time.sleep(retry_delay_s)
 
     def _create_time_status_publisher(
         self, time_status_step: timedelta, time_status_init: datetime

--- a/nost_tools/application.py
+++ b/nost_tools/application.py
@@ -276,7 +276,9 @@ class Application:
                 self.time_status_init = time_status_init
                 self.shut_down_when_terminated = shut_down_when_terminated
         else:
-            logger.info(f"Collecting parameters from user input or default values.")
+            logger.info(
+                f"Collecting start up parameters from user input or default values."
+            )
             self.set_offset = set_offset
             self.time_status_step = time_status_step
             self.time_status_init = time_status_init

--- a/nost_tools/application.py
+++ b/nost_tools/application.py
@@ -48,13 +48,19 @@ class Application:
         time_status_init (:obj:`datetime`): Scenario time of first time status message
     """
 
-    def __init__(self, app_name: str, app_description: str = None):
+    def __init__(
+        self,
+        app_name: str,
+        app_description: str = None,
+        setup_signal_handlers: bool = True,
+    ):
         """
         Initializes a new application.
 
         Args:
             app_name (str): application name
             app_description (str): application description (optional)
+            setup_signal_handlers (bool): whether to set up signal handlers (default: True)
         """
         self.simulator = Simulator()
         self.connection = None
@@ -86,7 +92,8 @@ class Application:
         self.token_refresh_interval = None
         self._reconnect_delay = None
         # Set up signal handlers for graceful shutdown
-        self._setup_signal_handlers()
+        if setup_signal_handlers:
+            self._setup_signal_handlers()
 
     def _setup_signal_handlers(self):
         """
@@ -203,14 +210,33 @@ class Application:
         """
         self.connection.update_secret(access_token, "secret")
 
+    def _get_parameters_from_config(self):
+        """
+        Gets application parameters from configuration or returns None if not available.
+        This method can be overridden by subclasses to customize parameter retrieval.
+
+        Returns:
+            object: Configuration parameters object or None
+        """
+        if self.config and self.config.rc.yaml_file:
+            try:
+                return getattr(
+                    self.config.rc.simulation_configuration.execution_parameters,
+                    "application",
+                    None,
+                )
+            except (AttributeError, KeyError):
+                return None
+        return None
+
     def start_up(
         self,
         prefix: str,
         config: ConnectionConfig,
-        set_offset: bool = None,  # True,
+        set_offset: bool = True,
         time_status_step: timedelta = None,
         time_status_init: datetime = None,
-        shut_down_when_terminated: bool = None,
+        shut_down_when_terminated: bool = False,
     ) -> None:
         """
         Starts up the application to prepare for scenario execution.
@@ -225,27 +251,41 @@ class Application:
             time_status_init (:obj:`datetime`): scenario time for first time status message
             shut_down_when_terminated (bool): True, if the application should shut down when the simulation is terminated
         """
-        if (
-            set_offset is not None
-            and time_status_step is not None
-            and time_status_init is not None
-            and shut_down_when_terminated is not None
-        ):
+        self.config = config
+
+        if self.config.rc.yaml_file:
+            logger.info(
+                f"Collecting start up parameters from YAML configuration file {self.config.rc.yaml_file}"
+            )
+            parameters = self._get_parameters_from_config()
+            if parameters:
+                self.set_offset = getattr(parameters, "set_offset", set_offset)
+                self.time_status_step = getattr(
+                    parameters, "time_status_step", time_status_step
+                )
+                self.time_status_init = getattr(
+                    parameters, "time_status_init", time_status_init
+                )
+                self.shut_down_when_terminated = getattr(
+                    parameters, "shut_down_when_terminated", shut_down_when_terminated
+                )
+            else:
+                logger.warning("No parameters found in configuration, using defaults")
+                self.set_offset = set_offset
+                self.time_status_step = time_status_step
+                self.time_status_init = time_status_init
+                self.shut_down_when_terminated = shut_down_when_terminated
+        else:
+            logger.info(f"Collecting parameters from user input or default values.")
             self.set_offset = set_offset
             self.time_status_step = time_status_step
             self.time_status_init = time_status_init
             self.shut_down_when_terminated = shut_down_when_terminated
-        else:
-            self.config = config
-            parameters = getattr(
-                self.config.rc.simulation_configuration.execution_parameters,
-                "application",
-                None,
-            )
-            self.set_offset = parameters.set_offset
-            self.time_status_step = parameters.time_status_step
-            self.time_status_init = parameters.time_status_init
-            self.shut_down_when_terminated = parameters.shut_down_when_terminated
+
+        logger.info("Set offset: " f"{self.set_offset}")
+        logger.info("Time status step: " f"{self.time_status_step}")
+        logger.info("Time status init: " f"{self.time_status_init}")
+        logger.info("Shut down when terminated: " f"{self.shut_down_when_terminated}")
 
         if self.set_offset:
             # Set the system clock offset

--- a/nost_tools/application.py
+++ b/nost_tools/application.py
@@ -255,7 +255,7 @@ class Application:
 
         if self.config.rc.yaml_file:
             logger.info(
-                f"Collecting start up parameters from YAML configuration file {self.config.rc.yaml_file}"
+                f"Collecting start up parameters from YAML configuration file: {self.config.rc.yaml_file}"
             )
             parameters = self._get_parameters_from_config()
             if parameters:
@@ -283,11 +283,6 @@ class Application:
             self.time_status_step = time_status_step
             self.time_status_init = time_status_init
             self.shut_down_when_terminated = shut_down_when_terminated
-
-        logger.info("Set offset: " f"{self.set_offset}")
-        logger.info("Time status step: " f"{self.time_status_step}")
-        logger.info("Time status init: " f"{self.time_status_init}")
-        logger.info("Shut down when terminated: " f"{self.shut_down_when_terminated}")
 
         if self.set_offset:
             # Set the system clock offset
@@ -332,7 +327,6 @@ class Application:
             locale=config.rc.server_configuration.servers.rabbitmq.locale,
             blocked_connection_timeout=config.rc.server_configuration.servers.rabbitmq.blocked_connection_timeout,
         )
-        logger.info(parameters)
 
         # Configure transport layer security (TLS) if needed
         if self.config.rc.server_configuration.servers.rabbitmq.tls:

--- a/nost_tools/configuration.py
+++ b/nost_tools/configuration.py
@@ -333,4 +333,5 @@ class ConnectionConfig:
             server_configuration=server_config,
             simulation_configuration=self.simulation_config,
             application_configuration=self.app_specific,
+            yaml_file=self.yaml_file,
         )

--- a/nost_tools/configuration.py
+++ b/nost_tools/configuration.py
@@ -21,6 +21,7 @@ from .schemas import (
     RuntimeConfig,
     ServersConfig,
     SimulationConfig,
+    WallclockOffsetProperties,
 )
 
 logger = logging.getLogger(__name__)
@@ -316,10 +317,7 @@ class ConnectionConfig:
             del server_config.execution
         self.server_config = server_config
 
-        if (
-            self.username is not None
-            and self.password is not None
-        ):
+        if self.username is not None and self.password is not None:
             logger.info("Using user-provided credentials.")
             self.credentials_config = Credentials(
                 username=self.username,
@@ -331,6 +329,7 @@ class ConnectionConfig:
             self.load_environment_variables()
 
         self.rc = RuntimeConfig(
+            wallclock_offset_properties=WallclockOffsetProperties(),
             credentials=self.credentials_config,
             server_configuration=server_config,
             simulation_configuration=self.simulation_config,

--- a/nost_tools/configuration.py
+++ b/nost_tools/configuration.py
@@ -52,6 +52,7 @@ class ConnectionConfig:
         password: str = None,
         rabbitmq_host: str = None,
         rabbitmq_port: int = None,
+        keycloak_authentication: bool = False,
         keycloak_host: str = None,
         keycloak_port: int = None,
         keycloak_realm: str = None,
@@ -70,6 +71,7 @@ class ConnectionConfig:
             password (str): client password, provided by NOS-T operator
             host (str): broker hostname
             rabbitmq_port (int): RabbitMQ broker port number
+            keycloak_authentication (bool): True, if Keycloak IAM authentication is used
             keycloak_port (int): Keycloak IAM port number
             keycloak_realm (str): Keycloak realm name
             client_id (str): Keycloak client ID
@@ -84,6 +86,7 @@ class ConnectionConfig:
         self.rabbitmq_host = rabbitmq_host
         self.keycloak_host = keycloak_host
         self.rabbitmq_port = rabbitmq_port
+        self.keycloak_authentication = keycloak_authentication
         self.keycloak_port = keycloak_port
         self.keycloak_realm = keycloak_realm
         self.client_id = client_id
@@ -283,6 +286,7 @@ class ConnectionConfig:
                             port=self.rabbitmq_port,
                             virtual_host=self.virtual_host,
                             tls=self.is_tls,
+                            keycloak_authentication=self.keycloak_authentication,
                         ),
                         keycloak=KeycloakConfig(
                             host=self.keycloak_host,
@@ -315,10 +319,8 @@ class ConnectionConfig:
         if (
             self.username is not None
             and self.password is not None
-            and self.client_id is not None
-            and self.client_secret_key is not None
         ):
-            logger.info("Using provided credentials.")
+            logger.info("Using user-provided credentials.")
             self.credentials_config = Credentials(
                 username=self.username,
                 password=self.password,

--- a/nost_tools/managed_application.py
+++ b/nost_tools/managed_application.py
@@ -122,11 +122,6 @@ class ManagedApplication(Application):
             self.time_step = time_step
             self.manager_app_name = manager_app_name
 
-        logger.info(
-            f"Managed application '{self.app_name}' started with time step: {self.time_step}, "
-            f"manager app name: {self.manager_app_name}"
-        )
-
         # Register callback functions
         self.add_message_callback(
             app_name=self.manager_app_name,

--- a/nost_tools/managed_application.py
+++ b/nost_tools/managed_application.py
@@ -32,27 +32,57 @@ class ManagedApplication(Application):
         time_step (:obj:`timedelta`): scenario time step used in execution
     """
 
-    def __init__(self, app_name: str, app_description: str = None):
+    def __init__(
+        self,
+        app_name: str,
+        app_description: str = None,
+        setup_signal_handlers: bool = True,
+    ):
         """
         Initializes a new managed application.
 
         Args:
             app_name (str): application name
             app_description (str): application description
+            setup_signal_handlers (bool): whether to set up signal handlers (default: True)
         """
-        super().__init__(app_name, app_description)
+        super().__init__(
+            app_name, app_description, setup_signal_handlers=setup_signal_handlers
+        )
         self.time_step = None
         self._sim_start_time = None
         self._sim_stop_time = None
+
+    def _get_parameters_from_config(self):
+        """
+        Override to get parameters specific to managed applications
+
+        Returns:
+            object: Configuration parameters for this managed application
+        """
+        if self.config and self.config.rc.yaml_file:
+            try:
+                parameters = (
+                    self.config.rc.simulation_configuration.execution_parameters.managed_applications
+                )
+                try:
+                    # Try to get app-specific parameters
+                    return parameters[self.app_name]
+                except KeyError:
+                    # Fall back to default parameters
+                    return parameters.get("default")
+            except (AttributeError, KeyError):
+                return None
+        return None
 
     def start_up(
         self,
         prefix: str,
         config: ConnectionConfig,
-        set_offset: bool = None,
+        set_offset: bool = True,
         time_status_step: timedelta = None,
         time_status_init: datetime = None,
-        shut_down_when_terminated: bool = None,
+        shut_down_when_terminated: bool = False,
         time_step: timedelta = None,
         manager_app_name: str = None,
     ) -> None:
@@ -70,48 +100,32 @@ class ManagedApplication(Application):
             time_step (:obj:`timedelta`): scenario time step used in execution (Default: 1 second)
             manager_app_name (str): manager application name (Default: manager)
         """
-        if (
-            set_offset is not None
-            and time_status_step is not None
-            and time_status_init is not None
-            and shut_down_when_terminated is not None
-            and time_step is not None
-            and manager_app_name is not None
-        ):
-            self.set_offset = set_offset
-            self.time_status_step = time_status_step
-            self.time_status_init = time_status_init
-            self.shut_down_when_terminated = shut_down_when_terminated
-            self.time_step = time_step
-            self.manager_app_name = manager_app_name
-        else:
-            self.config = config
-            parameters = (
-                self.config.rc.simulation_configuration.execution_parameters.managed_applications
-            )
+        self.config = config
 
-            try:
-                parameters = parameters[self.app_name]
-            except KeyError:
-                parameters = parameters["default"]
-            self.set_offset = parameters.set_offset
-            self.time_status_step = parameters.time_status_step
-            self.time_status_init = parameters.time_status_init
-            self.shut_down_when_terminated = parameters.shut_down_when_terminated
-            self.time_step = parameters.time_step
-            self.manager_app_name = parameters.manager_app_name
-
-        # start up base application
+        # Call base start_up to handle common parameters
         super().start_up(
             prefix,
             config,
-            self.set_offset,
-            self.time_status_step,
-            self.time_status_init,
-            self.shut_down_when_terminated,
+            set_offset,
+            time_status_step,
+            time_status_init,
+            shut_down_when_terminated,
         )
-        self.time_step = self.time_step
-        self.manager_app_name = self.manager_app_name
+
+        # Get additional parameters specific to managed applications
+        if self.config.rc.yaml_file:
+            parameters = self._get_parameters_from_config()
+            if parameters:
+                self.time_step = parameters.time_step
+                self.manager_app_name = parameters.manager_app_name
+        else:
+            self.time_step = time_step
+            self.manager_app_name = manager_app_name
+
+        logger.info(
+            f"Managed application '{self.app_name}' started with time step: {self.time_step}, "
+            f"manager app name: {self.manager_app_name}"
+        )
 
         # Register callback functions
         self.add_message_callback(

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -165,8 +165,6 @@ class Manager(Application):
         time_status_step: timedelta = None,
         time_status_init: datetime = None,
         shut_down_when_terminated: bool = False,
-        # time_step: timedelta = None,
-        # manager_app_name: str = None,
     ) -> None:
         """
         Starts up the application by connecting to message broker, starting a background event loop,
@@ -179,8 +177,6 @@ class Manager(Application):
             time_status_step (:obj:`timedelta`): scenario duration between time status messages
             time_status_init (:obj:`datetime`): scenario time for first time status message
             shut_down_when_terminated (bool): True, if the application should shut down when the simulation is terminated
-            time_step (:obj:`timedelta`): scenario time step used in execution (Default: 1 second)
-            manager_app_name (str): manager application name (Default: manager)
         """
         self.config = config
 
@@ -248,7 +244,7 @@ class Manager(Application):
         """
         if self.config.rc.yaml_file:
             logger.info(
-                f"Collecting execution parameters from YAML configuration file {self.config.rc.yaml_file}"
+                f"Collecting execution parameters from YAML configuration file: {self.config.rc.yaml_file}"
             )
             parameters = getattr(
                 self.config.rc.simulation_configuration.execution_parameters,

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -567,8 +567,17 @@ class Manager(Application):
             app_topics="stop",
             payload=command.model_dump_json(by_alias=True),
         )
-        # # update the execution end time
-        # self.simulator.set_end_time(sim_stop_time)
+
+        # Update the execution end time if simulator is in EXECUTING mode
+        if self.simulator.get_mode() == Mode.EXECUTING:
+            try:
+                self.simulator.set_end_time(sim_stop_time)
+            except RuntimeError as e:
+                logger.warning(f"Could not set simulator end time: {e}")
+        else:
+            logger.debug(
+                "Skipping setting simulator end time as simulator is not in EXECUTING mode"
+            )
 
     def update(self, time_scale_factor: float, sim_update_time: datetime) -> None:
         """

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -67,12 +67,22 @@ class Manager(Application):
         required_apps_status (dict): Ready status for all required applications
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        app_name: str = "manager",
+        app_description: str = None,
+        setup_signal_handlers: bool = True,
+    ):
         """
         Initializes a new manager.
+
+        Attributes:
+            setup_signal_handlers (bool): whether to set up signal handlers (default: True)
         """
         # call super class constructor
-        super().__init__("manager")
+        super().__init__(
+            app_name, app_description, setup_signal_handlers=setup_signal_handlers
+        )
         self.required_apps_status = {}
 
         self.sim_start_time = None
@@ -129,16 +139,34 @@ class Manager(Application):
                     f"Heartbeat check: {remaining:.2f} seconds remaining in sleep"
                 )
 
+    def _get_parameters_from_config(self):
+        """
+        Override to get parameters specific to manager application
+
+        Returns:
+            object: Configuration parameters for the manager application
+        """
+        if self.config and self.config.rc.yaml_file:
+            try:
+                return getattr(
+                    self.config.rc.simulation_configuration.execution_parameters,
+                    "manager",
+                    None,
+                )
+            except (AttributeError, KeyError):
+                return None
+        return None
+
     def start_up(
         self,
         prefix: str,
         config: ConnectionConfig,
-        set_offset: bool = None,
+        set_offset: bool = True,
         time_status_step: timedelta = None,
         time_status_init: datetime = None,
-        shut_down_when_terminated: bool = None,
-        time_step: timedelta = None,
-        manager_app_name: str = None,
+        shut_down_when_terminated: bool = False,
+        # time_step: timedelta = None,
+        # manager_app_name: str = None,
     ) -> None:
         """
         Starts up the application by connecting to message broker, starting a background event loop,
@@ -154,42 +182,19 @@ class Manager(Application):
             time_step (:obj:`timedelta`): scenario time step used in execution (Default: 1 second)
             manager_app_name (str): manager application name (Default: manager)
         """
-        if (
-            set_offset is not None
-            and time_status_step is not None
-            and time_status_init is not None
-            and shut_down_when_terminated is not None
-            and time_step is not None
-            and manager_app_name is not None
-        ):
-            self.set_offset = set_offset
-            self.time_status_step = time_status_step
-            self.time_status_init = time_status_init
-            self.shut_down_when_terminated = shut_down_when_terminated
-            self.time_step = time_step
-            self.manager_app_name = manager_app_name
-        else:
-            self.config = config
-            parameters = (
-                self.config.rc.simulation_configuration.execution_parameters.manager
-            )
-            self.set_offset = parameters.set_offset
-            self.time_status_step = parameters.time_status_step
-            self.time_status_init = parameters.time_status_init
-            self.shut_down_when_terminated = parameters.shut_down_when_terminated
-            self.time_step = parameters.time_step
+        self.config = config
 
-        # start up base application
+        # Call base start_up to handle common parameters
         super().start_up(
             prefix,
             config,
-            self.set_offset,
-            self.time_status_step,
-            self.time_status_init,
-            self.shut_down_when_terminated,
+            set_offset,
+            time_status_step,
+            time_status_init,
+            shut_down_when_terminated,
         )
 
-        # Establish the exchange
+        # Additional manager-specific setup: establish the exchange
         self.establish_exchange()
 
     def execute_test_plan(self, *args, **kwargs) -> None:
@@ -241,8 +246,33 @@ class Manager(Application):
             init_retry_delay_s (float): number of seconds to wait between initialization commands while waiting for required applications
             init_max_retry (int): number of initialization commands while waiting for required applications before continuing to execution
         """
-        # Initialize parameters from arguments or config
-        if sim_start_time is not None and sim_stop_time is not None:
+        if self.config.rc.yaml_file:
+            logger.info(
+                f"Collecting execution parameters from YAML configuration file {self.config.rc.yaml_file}"
+            )
+            parameters = getattr(
+                self.config.rc.simulation_configuration.execution_parameters,
+                self.app_name,
+                None,
+            )
+            self.sim_start_time = parameters.sim_start_time
+            self.sim_stop_time = parameters.sim_stop_time
+            self.start_time = parameters.start_time
+            self.time_step = parameters.time_step
+            self.time_scale_factor = parameters.time_scale_factor
+            self.time_scale_updates = parameters.time_scale_updates
+            self.time_status_step = parameters.time_status_step
+            self.time_status_init = parameters.time_status_init
+            self.command_lead = parameters.command_lead
+            self.required_apps = [
+                app for app in parameters.required_apps if app != self.app_name
+            ]
+            self.init_retry_delay_s = parameters.init_retry_delay_s
+            self.init_max_retry = parameters.init_max_retry
+        else:
+            logger.info(
+                f"Collecting execution parameters from user input or default values."
+            )
             self.sim_start_time = sim_start_time
             self.sim_stop_time = sim_stop_time
             self.start_time = start_time
@@ -255,36 +285,10 @@ class Manager(Application):
             self.required_apps = required_apps
             self.init_retry_delay_s = init_retry_delay_s
             self.init_max_retry = init_max_retry
-        else:
-            if self.config.rc:
-                logger.info("Retrieving execution parameters from YAML file.")
-                parameters = getattr(
-                    self.config.rc.simulation_configuration.execution_parameters,
-                    self.app_name,
-                    None,
-                )
-                self.sim_start_time = parameters.sim_start_time
-                self.sim_stop_time = parameters.sim_stop_time
-                self.start_time = parameters.start_time
-                self.time_step = parameters.time_step
-                self.time_scale_factor = parameters.time_scale_factor
-                self.time_scale_updates = parameters.time_scale_updates
-                self.time_status_step = parameters.time_status_step
-                self.time_status_init = parameters.time_status_init
-                self.command_lead = parameters.command_lead
-                self.required_apps = [
-                    app for app in parameters.required_apps if app != self.app_name
-                ]
-                self.init_retry_delay_s = parameters.init_retry_delay_s
-                self.init_max_retry = parameters.init_max_retry
-            else:
-                raise ValueError(
-                    "No configuration runtime. Please provide simulation start and stop times."
-                )
 
         # Convert TimeScaleUpdateSchema objects to TimeScaleUpdate objects
         converted_updates = []
-        for update_schema in parameters.time_scale_updates:
+        for update_schema in self.time_scale_updates:
             converted_updates.append(
                 TimeScaleUpdate(
                     time_scale_factor=update_schema.time_scale_factor,
@@ -563,8 +567,8 @@ class Manager(Application):
             app_topics="stop",
             payload=command.model_dump_json(by_alias=True),
         )
-        # update the execution end time
-        self.simulator.set_end_time(sim_stop_time)
+        # # update the execution end time
+        # self.simulator.set_end_time(sim_stop_time)
 
     def update(self, time_scale_factor: float, sim_update_time: datetime) -> None:
         """

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -453,7 +453,7 @@ class LoggerApplicationConfig(BaseModel):
         timedelta(seconds=10), description="Time status step."
     )
     time_status_init: Optional[datetime] = Field(
-        datetime(2019, 3, 1, 0, 0, 0), description="Time status init."
+        datetime.now(), description="Time status init."
     )
     shut_down_when_terminated: Optional[bool] = Field(
         False, description="Shut down when terminated."

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -511,8 +511,8 @@ class ChannelConfig(BaseModel):
 
 
 class Credentials(BaseModel):
-    username: str = Field(..., description="Username for authentication.")
-    password: str = Field(..., description="Password for authentication.")
+    username: Optional[str] = Field("admin", description="Username for authentication.")
+    password: Optional[str] = Field("admin", description="Password for authentication.")
     client_id: Optional[str] = Field(None, description="Client ID for authentication.")
     client_secret_key: Optional[str] = Field(
         None, description="Client secret key for authentication."

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -471,7 +471,9 @@ class ApplicationConfig(BaseModel):
 
 
 class ExecConfig(BaseModel):
-    general: GeneralConfig
+    general: Optional[GeneralConfig] = Field(
+        None, description="General configuration for the execution."
+    )
     manager: Optional[ManagerConfig] = Field(None, description="Manager configuration.")
     managed_applications: Optional[Dict[str, ManagedApplicationConfig]] = Field(
         default_factory=lambda: {"default": ManagedApplicationConfig()},
@@ -511,9 +513,9 @@ class ChannelConfig(BaseModel):
 class Credentials(BaseModel):
     username: str = Field(..., description="Username for authentication.")
     password: str = Field(..., description="Password for authentication.")
-    client_id: Optional[str] = Field("", description="Client ID for authentication.")
+    client_id: Optional[str] = Field(None, description="Client ID for authentication.")
     client_secret_key: Optional[str] = Field(
-        "", description="Client secret key for authentication."
+        None, description="Client secret key for authentication."
     )
 
 
@@ -538,4 +540,7 @@ class RuntimeConfig(BaseModel):
     )
     application_configuration: Optional[Dict] = Field(
         None, description="Application-specific, user-provided configuration."
+    )
+    yaml_file: Optional[str] = Field(
+        None, description="Path to the YAML file containing the configuration."
     )

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -365,6 +365,10 @@ class ManagerConfig(BaseModel):
     shut_down_when_terminated: bool = Field(
         False, description="Shut down when terminated."
     )
+    is_scenario_time_step: bool = Field(
+        True,
+        description="If True, time_step is in scenario time and won't be scaled. If False, time_step is in wallclock time and will be scaled by the time scale factor.",
+    )
     is_scenario_time_status_step: bool = Field(
         True,
         description="If True, time_status_step is in scenario time and won't be scaled. If False, time_status_step is in wallclock time and will be scaled by the time scale factor.",
@@ -373,6 +377,16 @@ class ManagerConfig(BaseModel):
     @model_validator(mode="before")
     def scale_time(cls, values):
         time_scale_factor = values.get("time_scale_factor", 1.0)
+
+        if "time_step" in values and not values.get("is_scenario_time_step", True):
+            time_step = values["time_step"]
+            if isinstance(time_step, str):
+                hours, minutes, seconds = map(int, time_step.split(":"))
+                time_step = timedelta(hours=hours, minutes=minutes, seconds=seconds)
+            if isinstance(time_step, timedelta):
+                values["time_step"] = timedelta(
+                    seconds=time_step.total_seconds() * time_scale_factor
+                )
 
         if "time_status_step" in values and not values.get(
             "is_scenario_time_status_step", True

--- a/nost_tools/schemas.py
+++ b/nost_tools/schemas.py
@@ -307,8 +307,21 @@ class ServersConfig(BaseModel):
         return values
 
 
+class WallclockOffsetProperties(BaseModel):
+    """
+    Properties to report wallclock offset.
+    """
+
+    wallclock_offset_refresh_interval: Optional[int] = Field(
+        10800, description="Wallclock offset refresh interval, in seconds."
+    )
+    ntp_host: Optional[str] = Field(
+        "pool.ntp.org", description="NTP host for wallclock offset synchronization."
+    )
+
+
 class GeneralConfig(BaseModel):
-    prefix: str = Field("nost", description="Execution prefix.")
+    prefix: Optional[str] = Field("nost", description="Execution prefix.")
 
 
 class TimeScaleUpdateSchema(BaseModel):
@@ -531,6 +544,9 @@ class SimulationConfig(BaseModel):
 
 
 class RuntimeConfig(BaseModel):
+    wallclock_offset_properties: WallclockOffsetProperties = Field(
+        ..., description="Properties for wallclock offset."
+    )
     credentials: Credentials = Field(..., description="Credentials for authentication.")
     server_configuration: Config = (
         Field(..., description="Simulation configuration."),

--- a/nost_tools/simulator.py
+++ b/nost_tools/simulator.py
@@ -516,9 +516,7 @@ class Simulator(Observable):
         Args:
             wallclock_offset(:obj:`timedelta`): difference between system clock and trusted wallclock source
         """
-        if self._mode == Mode.EXECUTING:
-            raise RuntimeError("Cannot set wallclock offset: simulator is executing")
-        elif self._mode == Mode.TERMINATING:
+        if self._mode == Mode.TERMINATING:
             raise RuntimeError("Cannot set wallclock offset: simulator is terminating")
         self._wallclock_offset = wallclock_offset
 


### PR DESCRIPTION
Added:
- Introduced a boolean `setup_signal_handlers` (default=True) parameter for Application() class, which makes `self._setup_signal_handlers()` conditional. This prevents errors in nost-manager-backend. 
  - Added `setup_signal_handlers` argument (default=True) to `__init__` of `Manager` and `ManagedApplication` classes.
- Added `yaml_file` section to `RuntimeConfig` in both `schemas.py` and `configuration.py`. This attribute holds the path to YAML configuration file if provided; otherwise, it defaults to `None`.
- Introduced `_get_parameters_from_config()` in `Application`, `Manager`, and `ManagedApplication` to facilitate getting the application parameters from the YAML configuration or user-provided arguments based on `self.config.rc.yaml_file` being None or not. 
- Added `keycloak_authentication` argument to `__init__()` of `ConnectionConfig` class (default=False).
- Implemented `start_wallclock_refresh_thread()` which periodically updates the wallclock offset. 
- Added `WallclockOffsetProperties` to `schemas.py` that contains `wallclock_offset_refresh_interval` and `ntp_host` fields used in `start_wallclock_refresh_thread()`
- Implemented `is_scenario_time_step` in `ManagerConfig` class, similar to that of `ManagedApplicationConfig`

Updated:
- Made `general` section of `ExecConfig` optional in `schemas.py`for situations where YAML configuration file is not provided.
- Made `client_id` and `client_secret_key` in `Credentials` default to None.
- Changed `parameters.time_scale_updates` reference to `self.time_scale_updates` in `manager.py`.
- Updated code in `start_up()` related to the definition of parameters to use `_get_parameters_from_config()` subclasses to customize parameter retrieval in:
  - `Application` class of `application.py`
  - `Manager` class of `manager.py`
  - `ManagedApplication` class of `managed_application.py` 
- Updated `self.simulator.set_end_time(sim_stop_time)` from `stop()` in `manager.py` to run only if `self.simulator.get_mode() == Mode.EXECUTING`
- Removed `time_step` and `manager_app_name` arguments from `start_up()` in `Manager` class
- Modified `set_wallclock_offset()` in `simulator.py` to allow setting wallclock offset when in `Mode.EXECUTING`
- Update default value of `time_status_init` to `datetime.now()` in `ApplicationConfig` class