### PR TITLE
103 improve freeze events at high time scale factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,3 +164,9 @@ Updated:
 - Removed `WallclockOffsetProperties` class and `wallclock_offset_properties` section from `RuntimeConfig` in `schemas.py` and `configuration.py`.
 - Added `wallclock_offset_refresh_interval` and `ntp_host` to `GeneralConfig` class in `schemas.py`
 - Updated FireSat test suite to show examples of time scale updates and scenario time freezes.
+## 3.0.1
+Updated:
+- Removed the calculation of `target_resume_time` from the `freeze()` method in `manager.py`.
+A freeze event now persists until the resume time specified in the `FreezeCommand` message payload is reached. Previously, the resume time was calculated from the scenario time at which the `FreezeRequest` message was received by the manager (scenario time at message receipt + freeze duration), which could cause time drift.
+- Prevented a one-step early advance after RESUMING by ensuring the `_wait_for_tock()` method in `simulator.py` re-anchors epochs and waits until the next tick before advancing.
+- Updated the `on_manager_freeze()` method in `managed_application.py` to honor `simFreezeTime` from a `FreezeCommand`, aligning to the requested scenario time (via wallclock mapping) before calling `pause()` so all apps freeze at the same scenario time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ Updated:
 - Removed `WallclockOffsetProperties` class and `wallclock_offset_properties` section from `RuntimeConfig` in `schemas.py` and `configuration.py`.
 - Added `wallclock_offset_refresh_interval` and `ntp_host` to `GeneralConfig` class in `schemas.py`
 - Updated FireSat test suite to show examples of time scale updates and scenario time freezes.
+
 ## 3.0.1
 Updated:
 - Removed the calculation of `target_resume_time` from the `freeze()` method in `manager.py`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 3.0.0
+version: 3.0.1
 doi:
-date-released: 2025-08-18
+date-released: 2025-08-24
 url: "https://github.com/code-lab-org/nost-tools"

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/managed_application.py
+++ b/nost_tools/managed_application.py
@@ -324,7 +324,27 @@ class ManagedApplication(Application):
             message = body.decode("utf-8")
             params = FreezeCommand.model_validate_json(message).tasking_parameters
             logger.info(f"Received freeze command {message}")
-            # freeze simulation time
+
+            sim_freeze_time = params.sim_freeze_time
+            if sim_freeze_time is not None:
+                try:
+                    # Only wait if we haven't reached the requested sim time yet
+                    if self.simulator.get_time() < sim_freeze_time:
+                        target_wc = self.simulator.get_wallclock_time_at_simulation_time(sim_freeze_time)
+                        # Sleep in short intervals to keep responsiveness
+                        while True:
+                            now_wc = self.simulator.get_wallclock_time()
+                            remaining = (target_wc - now_wc).total_seconds()
+                            if remaining <= 0:
+                                break
+                            # Exit early if execution is stopping
+                            if self.simulator.get_mode() in (Mode.TERMINATING, Mode.TERMINATED):
+                                return
+                            time.sleep(min(0.5, max(0.01, remaining)))
+                except Exception as e:
+                    logger.warning(f"Could not align to simFreezeTime={sim_freeze_time}: {e}")
+
+            # Freeze simulation time
             self.simulator.pause()
 
         except Exception as e:

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -757,20 +757,6 @@ class Manager(Application):
                 )
                 return
 
-            # Compute authoritative resume time
-            target_resume_time = base + freeze_duration
-            # Optionally honor requested resume_time if it's later than base
-            if resume_time is not None and resume_time > base:
-                # Keep the earlier of the two if you want to minimize drift across nodes,
-                # or the later if you prefer never resuming before a requested time.
-                # Here we choose the later to avoid early resume vs. a peer's expectation.
-                target_resume_time = max(target_resume_time, resume_time)
-
-            logger.info(
-                f"Resume Time: requested={resume_time} calculated={target_resume_time} "
-                f"delta={abs((target_resume_time - (resume_time or target_resume_time)).total_seconds())}s"
-            )
-
             # Poll until we reach the target, allowing early exit and heartbeats
             while True:
                 mode = self.simulator.get_mode()
@@ -782,8 +768,11 @@ class Manager(Application):
                 ):
                     break
                 remaining = (
-                    target_resume_time - self.simulator.get_wallclock_time()
+                    resume_time - self.simulator.get_wallclock_time()
                 ).total_seconds()
+                logger.info(
+                    f"Resume Time: {resume_time} Current Scenario Time: {self.simulator.get_time()} Current Wall Clock Time: {self.simulator.get_wallclock_time()} Remaining time: {remaining}"
+                )
                 if remaining <= 0:
                     break
                 self._sleep_with_heartbeat(min(1.0, max(0.01, remaining)))

--- a/nost_tools/simulator.py
+++ b/nost_tools/simulator.py
@@ -312,8 +312,6 @@ class Simulator(Observable):
             self._wallclock_epoch = self.get_wallclock_time()
             self._simulation_epoch = self._time
             self._set_mode(Mode.EXECUTING)
-            # Return immediately after resume to avoid waiting
-            return
         while (
             self._mode == Mode.EXECUTING
             and self.get_wallclock_time_at_simulation_time(self._next_time)
@@ -536,7 +534,7 @@ class Simulator(Observable):
         """
         Pauses the scenario execution. Requires that the simulator is in EXECUTING mode.
         """
-        logger.info("Pausing simulation execution.")
+        logger.info(f"Pausing simulation execution at {self._time}.")
         if self._mode != Mode.EXECUTING:
             raise RuntimeError("Cannot pause: simulator is not executing.")
 


### PR DESCRIPTION
Updated:
- Removed the calculation of `target_resume_time` from the `freeze()` method in `manager.py`.
A freeze event now persists until the resume time specified in the `FreezeCommand` message payload is reached. Previously, the resume time was calculated from the scenario time at which the `FreezeRequest` message was received by the manager (scenario time at message receipt + freeze duration), which could cause time drift.
- Prevented a one-step early advance after RESUMING by ensuring the `_wait_for_tock()` method in `simulator.py` re-anchors epochs and waits until the next tick before advancing.
- Updated the `on_manager_freeze()` method in `managed_application.py` to honor `simFreezeTime` from a `FreezeCommand`, aligning to the requested scenario time (via wallclock mapping) before calling `pause()` so all apps freeze at the same scenario time.