### PR TITLE
Dev v302

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,3 +171,8 @@ Updated:
 A freeze event now persists until the resume time specified in the `FreezeCommand` message payload is reached. Previously, the resume time was calculated from the scenario time at which the `FreezeRequest` message was received by the manager (scenario time at message receipt + freeze duration), which could cause time drift.
 - Prevented a one-step early advance after RESUMING by ensuring the `_wait_for_tock()` method in `simulator.py` re-anchors epochs and waits until the next tick before advancing.
 - Updated the `on_manager_freeze()` method in `managed_application.py` to honor `simFreezeTime` from a `FreezeCommand`, aligning to the requested scenario time (via wallclock mapping) before calling `pause()` so all apps freeze at the same scenario time.
+
+## 3.0.2
+Updated:
+- Removed `self._next_time = self._time` from `resume()` in `simulator.py`, which was causing a drift of approximately 1 second per simulated day.
+- Changed a log statement in `freeze()` within `manager.py` from log.info to log.debug to reduce verbosity. The affected line reports the remaining time during a freeze.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 3.0.1
+version: 3.0.2
 doi:
-date-released: 2025-08-24
+date-released: 2025-09-01
 url: "https://github.com/code-lab-org/nost-tools"

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -770,7 +770,7 @@ class Manager(Application):
                 remaining = (
                     resume_time - self.simulator.get_wallclock_time()
                 ).total_seconds()
-                logger.info(
+                logger.debug(
                     f"Resume Time: {resume_time} Current Scenario Time: {self.simulator.get_time()} Current Wall Clock Time: {self.simulator.get_wallclock_time()} Remaining time: {remaining}"
                 )
                 if remaining <= 0:

--- a/nost_tools/simulator.py
+++ b/nost_tools/simulator.py
@@ -546,7 +546,6 @@ class Simulator(Observable):
         """
         if self._mode not in [Mode.PAUSING, Mode.PAUSED]:
             raise RuntimeError("Cannot resume: simulator is not pausing or paused.")
-        self._next_time = self._time
         self._set_mode(Mode.RESUMING)
 
     def terminate(self) -> None:


### PR DESCRIPTION
- Removed `self._next_time = self._time` from `resume()` in `simulator.py`, which was causing a drift of approximately 1 second per simulated day.
- Changed a log statement in `freeze()` within `manager.py` from log.info to log.debug to reduce verbosity. The affected line reports the remaining time during a freeze.