### PR TITLE
114 pin python keycloak to 7 for python 39 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,3 +296,10 @@ Changed:
   - Changed error handler to use `threading.Timer` instead of `ioloop.call_later()` for retry scheduling, since ioloop state may be
 inconsistent during failures
   - Reconnection now works reliably regardless of simulator mode (executing, paused, etc.)
+
+## 3.0.7
+Changed:
+- **Python-Keycloak Version Constraint**: Pinned `python-keycloak` dependency to `>=5, <7` in `pyproject.toml`:
+  - Version 7.0.0+ uses PEP 604 union type syntax (`str | Role`) which requires Python 3.10+
+  - This constraint maintains compatibility with Python 3.9 (`requires-python = ">=3.9"`)
+  - Can be relaxed when `nost_tools` drops Python 3.9 support or upstream adds `from __future__ import annotations`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 3.0.6
+version: 3.0.7
 doi:
-date-released: 2026-01-30
+date-released: 2026-02-02
 url: "https://github.com/code-lab-org/nost-tools"

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.6"
+__version__ = "3.0.7"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pika >= 1",
     "python-dotenv",
     "pyyaml",
-    "python-keycloak >= 5"
+    "python-keycloak >=5, <7"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Changed:
- **Python-Keycloak Version Constraint**: Pinned `python-keycloak` dependency to `>=5, <7` in `pyproject.toml`:
  - Version 7.0.0+ uses PEP 604 union type syntax (`str | Role`) which requires Python 3.10+
  - This constraint maintains compatibility with Python 3.9 (`requires-python = ">=3.9"`)
  - Can be relaxed when `nost_tools` drops Python 3.9 support or upstream adds `from __future__ import annotations`