### PR TITLE
116 manager sends stopcommand too early when freeze occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,3 +303,11 @@ Changed:
   - Version 7.0.0+ uses PEP 604 union type syntax (`str | Role`) which requires Python 3.10+
   - This constraint maintains compatibility with Python 3.9 (`requires-python = ">=3.9"`)
   - Can be relaxed when `nost_tools` drops Python 3.9 support or upstream adds `from __future__ import annotations`
+
+## 3.0.8
+Fixed:
+- **Manager Stop Command Timing During Freezes** (`manager.py`): Fixed bug where Manager sent Stop command at the originally expected time instead of accounting for freeze duration:
+  - Added pause mode check in `_execute_test_plan_impl()` waiting loop to skip stop time calculations while simulator is in `PAUSED` or `PAUSING` mode
+  - Prevents race condition where stale `_wallclock_epoch` and `_simulation_epoch` values caused incorrect stop time calculations during freezes
+  - Stop command now correctly sent at `original_expected_time + freeze_duration` (e.g., 10 minutes total wallclock time for 5-minute execution + 5-minute freeze)
+  - Ensures proper synchronization between Manager's waiting logic and Simulator's freeze/resume cycle

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 3.0.7
+version: 3.0.8
 doi:
-date-released: 2026-02-02
+date-released: 2026-02-05
 url: "https://github.com/code-lab-org/nost-tools"

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.7"
+__version__ = "3.0.8"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -508,6 +508,12 @@ class Manager(Application):
 
         # Wait for stop time - simulator now handles freeze time internally
         while True:
+            # Skip stop time calculation if simulator is paused/pausing
+            # The epochs will be stale until resume, so wait for resume first
+            if self.simulator.get_mode() in (Mode.PAUSED, Mode.PAUSING):
+                time.sleep(0.1)
+                continue
+
             end_time = self.simulator.get_wallclock_time_at_simulation_time(
                 self.simulator.get_end_time()
             )


### PR DESCRIPTION
Fixed:
- **Manager Stop Command Timing During Freezes** (`manager.py`): Fixed bug where Manager sent Stop command at the originally expected time instead of accounting for freeze duration:
  - Added pause mode check in `_execute_test_plan_impl()` waiting loop to skip stop time calculations while simulator is in `PAUSED` or `PAUSING` mode
  - Prevents race condition where stale `_wallclock_epoch` and `_simulation_epoch` values caused incorrect stop time calculations during freezes
  - Stop command now correctly sent at `original_expected_time + freeze_duration` (e.g., 10 minutes total wallclock time for 5-minute execution + 5-minute freeze)
  - Ensures proper synchronization between Manager's waiting logic and Simulator's freeze/resume cycle