### PR TITLE
119 scenariotimeintervalcallback drifts when interval is not exactly 24 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,3 +311,11 @@ Fixed:
   - Prevents race condition where stale `_wallclock_epoch` and `_simulation_epoch` values caused incorrect stop time calculations during freezes
   - Stop command now correctly sent at `original_expected_time + freeze_duration` (e.g., 10 minutes total wallclock time for 5-minute execution + 5-minute freeze)
   - Ensures proper synchronization between Manager's waiting logic and Simulator's freeze/resume cycle
+
+## 3.0.9
+Changed:
+- **ScenarioTimeIntervalCallback Initial Offset** (`observer.py`): Added optional `time_init` parameter to `ScenarioTimeIntervalCallback` to decouple the initial trigger offset from the repeating interval:
+  - Previously, the initial offset and repeating interval were always the same value, causing cumulative drift when the interval was not exactly 24 hours (e.g., `timedelta(hours=23, minutes=55)` drifted 5 minutes earlier each day)
+  - New `time_init` parameter sets the offset for the first trigger independently from `time_interval`
+  - When omitted, defaults to `time_interval` (backward compatible)
+  - Example: `ScenarioTimeIntervalCallback(callback, timedelta(days=1), time_init=timedelta(hours=23, minutes=55))` fires at 23:55 daily without drift

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 3.0.8
+version: 3.0.9
 doi:
-date-released: 2026-02-05
+date-released: 2026-03-07
 url: "https://github.com/code-lab-org/nost-tools"

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.8"
+__version__ = "3.0.9"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/observer.py
+++ b/nost_tools/observer.py
@@ -207,10 +207,14 @@ class ScenarioTimeIntervalCallback(Observer):
     """
 
     def __init__(
-        self, callback: Callable[[object, datetime], None], time_inteval: timedelta
+        self,
+        callback: Callable[[object, datetime], None],
+        time_inteval: timedelta,
+        time_init: Optional[timedelta] = None,
     ):
         self.callback = callback
         self.time_interval = time_inteval
+        self.time_init = time_init
         self._next_time = None
 
     def on_change(
@@ -218,7 +222,8 @@ class ScenarioTimeIntervalCallback(Observer):
     ):
         if property_name == source.PROPERTY_TIME:
             if self._next_time is None:
-                self._next_time = old_value + self.time_interval
+                init = self.time_init if self.time_init is not None else self.time_interval
+                self._next_time = old_value + init
             while self._next_time <= new_value:
                 self.callback(source, self._next_time)
                 self._next_time = self._next_time + self.time_interval


### PR DESCRIPTION
Changed:
- **ScenarioTimeIntervalCallback Initial Offset** (`observer.py`): Added optional `time_init` parameter to `ScenarioTimeIntervalCallback` to decouple the initial trigger offset from the repeating interval:
  - Previously, the initial offset and repeating interval were always the same value, causing cumulative drift when the interval was not exactly 24 hours (e.g., `timedelta(hours=23, minutes=55)` drifted 5 minutes earlier each day)
  - New `time_init` parameter sets the offset for the first trigger independently from `time_interval`
  - When omitted, defaults to `time_interval` (backward compatible)
  - Example: `ScenarioTimeIntervalCallback(callback, timedelta(days=1), time_init=timedelta(hours=23, minutes=55))` fires at 23:55 daily without drift