### PR TITLE
124 support pre acquired keycloak tokens in applicationstart up for server side per user rabbitmq access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,3 +319,18 @@ Changed:
   - New `time_init` parameter sets the offset for the first trigger independently from `time_interval`
   - When omitted, defaults to `time_interval` (backward compatible)
   - Example: `ScenarioTimeIntervalCallback(callback, timedelta(days=1), time_init=timedelta(hours=23, minutes=55))` fires at 23:55 daily without drift
+
+## 3.1.0
+Added:
+- **Pre-acquired Token Authentication Mode** (`application.py`, `manager.py`, `managed_application.py`): Added optional `access_token` and `refresh_token` keyword arguments to `Application.start_up()`, `Manager.start_up()`, and `ManagedApplication.start_up()`:
+  - Enables a third Keycloak authentication mode, complementing existing user (username/password) and service account (client_credentials) modes
+  - When both tokens are provided, `start_up()` skips the Keycloak grant and uses the pre-acquired tokens directly to authenticate the RabbitMQ connection
+  - The existing background refresh thread continues to renew the session by calling Keycloak's refresh endpoint with the forwarded refresh token — works for public clients without a `client_secret_key`
+  - Intended for server-side components (e.g., a backend API) that receive user tokens from an authenticated frontend and need to act on behalf of that user against RabbitMQ, preserving per-user broker scope enforcement
+  - Raises `ValueError` if `access_token` is provided without `refresh_token`, since the refresh thread requires a refresh token to keep the session alive
+  - Fully backwards-compatible: existing callers that do not pass the new kwargs retain identical behavior
+
+Changed:
+- **Initial Refresh Token Capture** (`application.py`): In the default Keycloak authentication path, `start_up()` now captures the refresh token returned from the initial `new_access_token()` call and stores it on `self.refresh_token` before starting the refresh thread:
+  - Previously, the returned refresh token was discarded, causing the refresh thread's first tick to perform a redundant full grant
+  - No behavior change for callers; removes one unnecessary Keycloak round-trip during startup

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
     given-names: "Matthew J."
     orcid: "https://orcid.org/0000-0002-1972-9227"
 title: "New Observing Strategies Testbed (NOS-T)"
-version: 3.0.9
+version: 3.1.0
 doi:
-date-released: 2026-03-07
+date-released: 2026-04-15
 url: "https://github.com/code-lab-org/nost-tools"

--- a/docs/source/operators_guide/modules/authentication_modes.rst
+++ b/docs/source/operators_guide/modules/authentication_modes.rst
@@ -3,7 +3,7 @@
 Authentication Modes
 ====================
 
-NOS-T supports three authentication modes for connecting to the RabbitMQ message broker. The mode is automatically detected based on the credentials provided in the ``.env`` file and the ``keycloak_authentication`` setting in the YAML configuration.
+NOS-T supports four authentication modes for connecting to the RabbitMQ message broker. The first three are automatically detected based on the credentials provided in the ``.env`` file and the ``keycloak_authentication`` setting in the YAML configuration. The fourth (pre-acquired tokens) is selected by passing tokens directly to ``start_up()`` and is intended for server-side components acting on behalf of an already-authenticated end user.
 
 Overview
 --------
@@ -27,6 +27,10 @@ Overview
    * - Keycloak User Account
      - Interactive users with OTP/2FA
      - ``USERNAME`` + ``PASSWORD`` + ``CLIENT_ID`` + ``CLIENT_SECRET_KEY``
+     - ``True``
+   * - Keycloak Pre-acquired Tokens
+     - Server-side delegation (act on behalf of an authenticated user)
+     - ``CLIENT_ID`` + ``access_token`` + ``refresh_token`` (passed to ``start_up()``)
      - ``True``
 
 Basic Auth (Localhost/Development)
@@ -116,6 +120,45 @@ For programmatic OTP support, pass the ``otp`` parameter to ``new_access_token()
 .. code-block:: python
 
    app.new_access_token(otp="123456")
+
+Keycloak Pre-acquired Tokens
+----------------------------
+
+For server-side components (e.g., a backend API) that receive tokens from an already-authenticated end user and need to act on behalf of that user against RabbitMQ. In this mode, ``nost_tools`` does not perform a Keycloak grant itself; instead, it uses tokens obtained elsewhere (typically forwarded from a frontend that completed an Authorization Code flow).
+
+This preserves per-user RabbitMQ scope enforcement end-to-end: every publish performed by the server-side ``Application`` or ``Manager`` is authenticated with the original user's token, so RabbitMQ's OAuth2 plugin applies the user's group-based permissions (e.g., ``rabbitmq.configure:*/sos*/sos*``) to each operation.
+
+**YAML configuration:** Same as Service Account (above).
+
+**.env file:**
+
+.. code-block:: bash
+
+   CLIENT_ID="nost_monitor_nodejs"
+
+Set ``CLIENT_ID`` to the Keycloak client that originally issued the forwarded tokens (the refresh endpoint requires the ``client_id`` to match). For public clients, ``CLIENT_SECRET_KEY`` is not required. ``USERNAME`` and ``PASSWORD`` are not used in this mode.
+
+**Usage:**
+
+Pass the forwarded tokens as keyword arguments to ``start_up()``:
+
+.. code-block:: python
+
+   manager = Manager()
+   manager.start_up(
+       prefix="my_scenario",
+       config=config,
+       access_token=user_access_token,
+       refresh_token=user_refresh_token,
+   )
+
+The background refresh thread renews the session by calling Keycloak's refresh endpoint with the provided refresh token on the normal ``token_refresh_interval`` cadence, so long-running scenarios (hours, days, or longer — bounded by Keycloak's SSO session settings) remain continuously authenticated without further action from the caller.
+
+**Requirements:**
+
+- Both ``access_token`` and ``refresh_token`` must be provided. Passing ``access_token`` alone raises ``ValueError`` at startup, because the refresh thread cannot keep the session alive without a refresh token.
+- The Keycloak client identified by ``CLIENT_ID`` must permit refresh via ``grant_type=refresh_token`` (default for public clients issued via Authorization Code flow).
+- The user whose tokens are forwarded must have whatever RabbitMQ scopes the scenario requires, projected into the token's ``extra_scope`` claim through the usual Keycloak mapper configuration.
 
 Credentials Validation
 ----------------------

--- a/nost_tools/__init__.py
+++ b/nost_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.9"
+__version__ = "3.1.0"
 
 from .application import Application
 from .application_utils import ConnectionConfig, ModeStatusObserver, TimeStatusPublisher

--- a/nost_tools/application.py
+++ b/nost_tools/application.py
@@ -346,11 +346,22 @@ class Application:
         time_status_step: timedelta = None,
         time_status_init: datetime = None,
         shut_down_when_terminated: bool = False,
+        access_token: str = None,
+        refresh_token: str = None,
     ) -> None:
         """
         Starts up the application to prepare for scenario execution.
         Connects to the message broker and starts a background event loop by establishing the simulation prefix,
         the connection configuration, and the intervals for publishing time status messages.
+
+        Three Keycloak authentication modes are supported:
+        1. User authentication: username + password in ConnectionConfig credentials.
+        2. Service account: client_id + client_secret_key in ConnectionConfig credentials.
+        3. Pre-acquired token: access_token + refresh_token passed here directly.
+           Use this mode when tokens were obtained elsewhere (e.g., forwarded from
+           a frontend login). The refresh thread will keep the session alive by
+           calling the Keycloak refresh endpoint using the configured client_id.
+           For public clients, no client_secret_key is required.
 
         Args:
             prefix (str): messaging namespace (prefix)
@@ -359,6 +370,8 @@ class Application:
             time_status_step (:obj:`timedelta`): scenario duration between time status messages
             time_status_init (:obj:`datetime`): scenario time for first time status message
             shut_down_when_terminated (bool): True, if the application should shut down when the simulation is terminated
+            access_token (str): pre-acquired Keycloak access token (optional; requires refresh_token)
+            refresh_token (str): pre-acquired Keycloak refresh token (required when access_token is provided)
         """
         self.config = config
 
@@ -424,9 +437,19 @@ class Application:
             logger.info(
                 f"Keycloak authentication is enabled. Access token will be refreshed every {self.token_refresh_interval} seconds"
             )
-            access_token, _ = self.new_access_token()
+            if access_token is not None:
+                if refresh_token is None:
+                    raise ValueError(
+                        "refresh_token is required when access_token is provided "
+                        "so the refresh thread can renew the session."
+                    )
+                logger.info("Using pre-acquired access + refresh tokens; skipping Keycloak grant.")
+                self.refresh_token = refresh_token
+                initial_access_token = access_token
+            else:
+                initial_access_token, self.refresh_token = self.new_access_token()
             self.start_token_refresh_thread()
-            credentials = pika.PlainCredentials("", access_token)
+            credentials = pika.PlainCredentials("", initial_access_token)
         else:
             # Set up credentials
             credentials = pika.PlainCredentials(

--- a/nost_tools/managed_application.py
+++ b/nost_tools/managed_application.py
@@ -98,6 +98,8 @@ class ManagedApplication(Application):
         shut_down_when_terminated: bool = False,
         time_step: timedelta = None,
         manager_app_name: str = None,
+        access_token: str = None,
+        refresh_token: str = None,
     ) -> None:
         """
         Starts up the application by connecting to message broker, starting a background event loop,
@@ -112,6 +114,8 @@ class ManagedApplication(Application):
             shut_down_when_terminated (bool): True, if the application should shut down when the simulation is terminated
             time_step (:obj:`timedelta`): scenario time step used in execution (Default: 1 second)
             manager_app_name (str): manager application name (Default: manager)
+            access_token (str): pre-acquired Keycloak access token (optional; requires refresh_token)
+            refresh_token (str): pre-acquired Keycloak refresh token (required when access_token is provided)
         """
         self.config = config
 
@@ -123,6 +127,8 @@ class ManagedApplication(Application):
             time_status_step,
             time_status_init,
             shut_down_when_terminated,
+            access_token=access_token,
+            refresh_token=refresh_token,
         )
 
         # Get additional parameters specific to managed applications

--- a/nost_tools/manager.py
+++ b/nost_tools/manager.py
@@ -135,6 +135,8 @@ class Manager(Application):
         time_status_step: timedelta = None,
         time_status_init: datetime = None,
         shut_down_when_terminated: bool = False,
+        access_token: str = None,
+        refresh_token: str = None,
     ) -> None:
         """
         Starts up the application by connecting to message broker, starting a background event loop,
@@ -147,6 +149,8 @@ class Manager(Application):
             time_status_step (:obj:`timedelta`): scenario duration between time status messages
             time_status_init (:obj:`datetime`): scenario time for first time status message
             shut_down_when_terminated (bool): True, if the application should shut down when the simulation is terminated
+            access_token (str): pre-acquired Keycloak access token (optional; requires refresh_token)
+            refresh_token (str): pre-acquired Keycloak refresh token (required when access_token is provided)
         """
         self.config = config
 
@@ -158,6 +162,8 @@ class Manager(Application):
             time_status_step,
             time_status_init,
             shut_down_when_terminated,
+            access_token=access_token,
+            refresh_token=refresh_token,
         )
 
         # Register callbacks for freeze, resume, and update requests from managed applications


### PR DESCRIPTION
Added:
- **Pre-acquired Token Authentication Mode** (`application.py`, `manager.py`, `managed_application.py`): Added optional `access_token` and `refresh_token` keyword arguments to `Application.start_up()`, `Manager.start_up()`, and `ManagedApplication.start_up()`:
  - Enables a third Keycloak authentication mode, complementing existing user (username/password) and service account (client_credentials) modes
  - When both tokens are provided, `start_up()` skips the Keycloak grant and uses the pre-acquired tokens directly to authenticate the RabbitMQ connection
  - The existing background refresh thread continues to renew the session by calling Keycloak's refresh endpoint with the forwarded refresh token — works for public clients without a `client_secret_key`
  - Intended for server-side components (e.g., a backend API) that receive user tokens from an authenticated frontend and need to act on behalf of that user against RabbitMQ, preserving per-user broker scope enforcement
  - Raises `ValueError` if `access_token` is provided without `refresh_token`, since the refresh thread requires a refresh token to keep the session alive
  - Fully backwards-compatible: existing callers that do not pass the new kwargs retain identical behavior

Changed:
- **Initial Refresh Token Capture** (`application.py`): In the default Keycloak authentication path, `start_up()` now captures the refresh token returned from the initial `new_access_token()` call and stores it on `self.refresh_token` before starting the refresh thread:
  - Previously, the returned refresh token was discarded, causing the refresh thread's first tick to perform a redundant full grant
  - No behavior change for callers; removes one unnecessary Keycloak round-trip during startup